### PR TITLE
Refine dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pfsspecsim @ git+https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git",
     "loguru>=0.7.2",
     "mkdocs-video>=1.5.0",
+    "watchfiles>=0.21.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"
@@ -69,6 +70,8 @@ gen-requirements = { cmd = [
     "mkdocs",
     "--output",
     "requirements.txt",
+    "--pyproject",
+    "--editable-self",
     "--verbose",
 ], help = "Generate requirements.txt" }
 serve-app = { cmd = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ ruff>=0.0.239
 setuptools>=56.1.0
 specutils>=1.10.0
 synphot>=1.2.0
+watchfiles>=0.21.0
+-e .  # this package


### PR DESCRIPTION
- Generate requirements.txt from pyproject.toml (not from pdm.lock)
- Add watchfiles as a dependency recommended for Panel 1.4+