### PR TITLE
Set the default value of Moon Zenith Angle to 60 degree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,11 @@ dependencies = [
     "watchfiles>=0.21.0",
     "importlib_metadata",
 ]
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.12,<3.13"
 readme = "README.md"
 license = { text = "MIT" }
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 
@@ -107,4 +106,4 @@ version = { attr = "pfs_etc_web.__version__" }
 
 [tool.black]
 # line-length = 120
-target-version = ["py39", "py310", "py311"]
+target-version = ["py312"]

--- a/src/pfs_etc_web/pfs_etc_params.py
+++ b/src/pfs_etc_web/pfs_etc_params.py
@@ -28,7 +28,7 @@ class PfsSpecParameter:
     # observing condition
     seeing: float = 0.8
     degrade: float = 0.9  # conservative value
-    moon_zenith_angle: int = 30
+    moon_zenith_angle: int = 60 # 30 degree elevation
     moon_target_angle: int = 60
     moon_phase: int = 0.15  # or 0.10
 


### PR DESCRIPTION
- The previous default value of the moon zenith angle of 30 deg is unrealistic, so it's changed to 60 deg (elevation of 30 deg).
- Set the minimum Python version to 3.12 as there seems to be an error for asdf import (importlib_metadata).