### PR TITLE
use raw strings to escape regular and math expressions

### DIFF
--- a/src/pfs_etc_web/pfs_etc_utils.py
+++ b/src/pfs_etc_web/pfs_etc_utils.py
@@ -18,7 +18,7 @@ from . import PfsArm
 def load_simspec(infile: str) -> pd.DataFrame:
     df = pd.read_table(
         infile,
-        sep="\s+",
+        sep=r"\s+",
         comment="#",
         header=None,
         # header=0,
@@ -38,7 +38,7 @@ def load_simspec(infile: str) -> pd.DataFrame:
 def load_snline(infile: str) -> pd.DataFrame:
     df = pd.read_table(
         infile,
-        sep="\s+",
+        sep=r"\s+",
         comment="#",
         header=None,
         # header=0,
@@ -67,7 +67,7 @@ def load_snline(infile: str) -> pd.DataFrame:
 def load_sncont(infile: str) -> pd.DataFrame:
     df = pd.read_table(
         infile,
-        sep="\s+",
+        sep=r"\s+",
         comment="#",
         header=None,
         names=[

--- a/src/pfs_etc_web/pfs_etc_widgets.py
+++ b/src/pfs_etc_web/pfs_etc_widgets.py
@@ -117,10 +117,10 @@ class TargetWidgets(param.Parameterized):
             },
         )
         self.custom_input_help = pn.pane.Markdown(
-            "Input spectrum must be in a CSV format with exactly two columns. "
-            "The first column must be the wavelength in [Å] and "
-            "the second column must be the flux in [$$\mathrm{erg}$$ $$\mathrm{s}^{-1}$$ $$\mathrm{cm}^{-2}$$ $$\mathrm{Å}^{\ \ \ -1}$$]. "
-            'No header line is needed and lines starting with "#" are regarded as commment. An [example CSV file](https://gist.github.com/monodera/be48be04f376b2db268d0b14ad9cb5e1) is available.',
+            r"Input spectrum must be in a CSV format with exactly two columns. "
+            r"The first column must be the wavelength in [Å] and "
+            r"the second column must be the flux in [$$\mathrm{erg}$$ $$\mathrm{s}^{-1}$$ $$\mathrm{cm}^{-2}$$ $$\mathrm{Å}^{\ \ \ -1}$$]. "
+            r"No header line is needed and lines starting with '#' are regarded as commment. An [example CSV file](https://gist.github.com/monodera/be48be04f376b2db268d0b14ad9cb5e1) is available.",
             # renderer="myst"
             # markdown-it', 'markdown', 'myst
         )


### PR DESCRIPTION
By using raw strings for regular and math expressions, this PR suppresses SyntaxWarning listed below.

```
/work/monodera/gh/Subaru-PFS/spt_etc_webapp/src/pfs_etc_web/pfs_etc_utils.py:21: SyntaxWarning: invalid escape sequence '\s'
sep="\s+",
/work/monodera/gh/Subaru-PFS/spt_etc_webapp/src/pfs_etc_web/pfs_etc_utils.py:41: SyntaxWarning: invalid escape sequence '\s'
sep="\s+",
/work/monodera/gh/Subaru-PFS/spt_etc_webapp/src/pfs_etc_web/pfs_etc_utils.py:70: SyntaxWarning: invalid escape sequence '\s'
sep="\s+",
/work/monodera/gh/Subaru-PFS/spt_etc_webapp/src/pfs_etc_web/pfs_etc_widgets.py:122: SyntaxWarning: invalid escape sequence '\m'
"the second column must be the flux in [$$\mathrm{erg}$$ $$\mathrm{s}^{-1}$$ $$\mathrm{cm}^{-2}$$ $$\mathrm{Å}^{\ \ \ -1}$$]. "
```