### PR TITLE
Apply tombi formatting to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,30 @@ Repository = "https://github.com/Subaru-PFS/spt_etc_webapp"
 # The CLI provides basic functionality but lacks some features (static dirs, prefix, etc.)
 run_pfs_etc_web = "pfs_etc_web.cli.run_panel_server:main"
 
+[dependency-groups]
+dev = [
+  "black>=22.12.0",
+  "ipython>=8.9.0",
+  "pytest>=9.1.1",
+  "ruff>=0.0.239",
+  "ty>=0.0.5",
+  "watchfiles>=0.21.0",
+]
+docs = [
+  "fontawesome-markdown @ https://github.com/bmcorser/fontawesome-markdown/archive/master.zip",
+  "mkdocs>=1.4.3",
+  "mkdocs-macros-plugin>=0.7.0",
+  "mkdocs-material[imaging]>=9.5.3",
+  "mkdocs-video>=1.5.0",
+  "myst-parser>=1.0.0",
+]
+spectemplates = [
+  "matplotlib>=3.8.4",
+  "scipy",
+  "seaborn>=0.13.2",
+  "specutils>=1.10.0",
+]
+
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -77,27 +101,3 @@ version = { attr = "pfs_etc_web.__version__" }
 [tool.setuptools_scm]
 version_file = "src/pfs_etc_web/_version.py"
 fallback_version = "0.0.0+unknown"
-
-[dependency-groups]
-dev = [
-  "black>=22.12.0",
-  "ipython>=8.9.0",
-  "pytest>=9.1.1",
-  "ruff>=0.0.239",
-  "ty>=0.0.5",
-  "watchfiles>=0.21.0",
-]
-docs = [
-  "fontawesome-markdown @ https://github.com/bmcorser/fontawesome-markdown/archive/master.zip",
-  "mkdocs>=1.4.3",
-  "mkdocs-macros-plugin>=0.7.0",
-  "mkdocs-material[imaging]>=9.5.3",
-  "mkdocs-video>=1.5.0",
-  "myst-parser>=1.0.0",
-]
-spectemplates = [
-  "matplotlib>=3.8.4",
-  "scipy",
-  "seaborn>=0.13.2",
-  "specutils>=1.10.0",
-]


### PR DESCRIPTION
## Summary

- Runs the tombi formatter (configured in #68) on `pyproject.toml` for real. It reorders `[dependency-groups]` to right after `[project.scripts]` per tombi's schema-driven canonical table order — no content change.
- This was only tested and reverted while setting up the tombi hook in #68, never actually applied/committed before that PR merged, so main's `pyproject.toml` doesn't yet match what the new PostToolUse hook will produce on the next edit.

## Test plan

- [x] `uv lock --check` passes (no dependency resolution change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)